### PR TITLE
Ad/api calls

### DIFF
--- a/event.rb
+++ b/event.rb
@@ -9,5 +9,15 @@ class Event
     @end = info[:end].date_time.to_s
     @id = info[:id]
   end 
+
+  def info
+    data = Hash.new
+		data[:name] = @name 
+		data[:description] = @description
+		data[:start] = @start
+		data[:end] = @end
+    data[:id] = @id
+    data
+  end
   
 end

--- a/google_service.rb
+++ b/google_service.rb
@@ -16,7 +16,8 @@ class GoogleService < Sinatra::Base
   def self.create_new_calendar(token, refresh_token, name)
     service = refresh_authorization(token, refresh_token)
     calendar = Google::Apis::CalendarV3::Calendar.new(summary: name)
-    service.insert_calendar(calendar)
+    result = service.insert_calendar(calendar)
+    return {name: result.summary, id: result.id}
   end
 
   def self.delete_calendar(token, refresh_token, name)
@@ -40,7 +41,8 @@ class GoogleService < Sinatra::Base
         )
       )
     calendar_id = GoogleService.get_calendars(info[:token], info[:refresh_token])[info[:calendar]]
-    service.insert_event(calendar_id, event)
+    result = service.insert_event(calendar_id, event)
+    return {summary: result.summary, description: result.description, id: result.id}
   end
 
   def self.delete_event(token, refresh_token, calendar_id, event_id)

--- a/google_service_spec.rb
+++ b/google_service_spec.rb
@@ -17,16 +17,16 @@ RSpec.describe 'Notifications' do
     @calendar_id = GoogleService.get_calendars(@token, @refresh_token)["GardenThatApp"]
   end
 
-  xit "can return calendar information" do
+  it "can return calendar information" do
     list_calendars = ["gardenthat@gmail.com", "GardenThatApp"]
     expect(GoogleService.get_calendars(@token, @refresh_token).keys.to_set).to eq(list_calendars.to_set)
   end
 
-  xit "can create a new calendar" do
+  it "can create a new calendar" do
     expect(GoogleService.get_calendars(@token, @refresh_token).include?('test_calendar')).to eq(false)
     result = GoogleService.create_new_calendar(@token, @refresh_token, 'test_calendar')
     expect(GoogleService.get_calendars(@token, @refresh_token).include?('test_calendar')).to eq(true)
-    GoogleService.delete_calendar(@token, @refresh_token, result.id)
+    GoogleService.delete_calendar(@token, @refresh_token, result[:id])
   end
 
   it "can create a new event in the calendar" do
@@ -43,7 +43,7 @@ RSpec.describe 'Notifications' do
     expect(events.length).to eq(1)
     expect(events[0].name).to eq('Tomato time!!')
     expect(events[0].description).to eq("it's about time you harvest those tomatoes")
-    GoogleService.delete_event(@token, @refresh_token, @calendar_id, result.id)
+    GoogleService.delete_event(@token, @refresh_token, @calendar_id, result[:id])
   end
 
   it "can get return a list of events for a calendar" do
@@ -71,8 +71,8 @@ RSpec.describe 'Notifications' do
     expect(events[0].name).to eq(event1_info[:name]) 
     expect(events[1].name).to eq(event2_info[:name])
 
-    GoogleService.delete_event(@token, @refresh_token, @calendar_id, event1.id)
-    GoogleService.delete_event(@token, @refresh_token, @calendar_id, event2.id)
+    GoogleService.delete_event(@token, @refresh_token, @calendar_id, event1[:id])
+    GoogleService.delete_event(@token, @refresh_token, @calendar_id, event2[:id])
   end
 
 

--- a/notifications_spec.rb
+++ b/notifications_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Notifications' do
     expect(last_response.body).to eq('Hello World')
   end
 
-  xit "can create a new calendar" do
+  it "can create a new calendar" do
     token = ENV['TEST_USER_GOOGLE_TOKEN']
     refresh_token = ENV['TEST_USER_GOOGLE_REFRESH_TOKEN']
     expect(GoogleService.get_calendars(token, refresh_token).include?('test_calendar')).to eq(false)
@@ -42,6 +42,37 @@ RSpec.describe 'Notifications' do
     expect(events[0].start[0..9]).to eq('2020-05-23')
     expect(events[0].end[0..9]).to eq('2020-05-23')
     GoogleService.delete_event(token, refresh_token, calendar_id, events[0].id)
+  end
+
+  it "can get a list of events" do
+    token = ENV['TEST_USER_GOOGLE_TOKEN']
+    refresh_token = ENV['TEST_USER_GOOGLE_REFRESH_TOKEN']
+    calendar_id = GoogleService.get_calendars(token, refresh_token)["GardenThatApp"]
+    event1_info = {
+      token: token,
+      refresh_token: refresh_token,
+      calendar: 'GardenThatApp',
+      name: 'Tomato time!!',
+      description: "it's about time you harvest those tomatoes",
+      date: '2020-05-28'
+    }
+    event1 = GoogleService.create_event(event1_info)
+    event2_info = {
+      token: token,
+      refresh_token: refresh_token,
+      calendar: 'GardenThatApp',
+      name: 'Mint time!!',
+      description: "Your mint will be just right in about 10 days",
+      date: '2020-06-05'
+    }
+    event2 = GoogleService.create_event(event2_info)
+
+    events = GoogleService.get_list_events(token, refresh_token, calendar_id)
+
+    get "/events/info?token=#{token}&refresh_token=#{refresh_token}&calendar_name=GardenThatApp"
+  
+    GoogleService.delete_event(token, refresh_token, calendar_id, events[0].id)
+    GoogleService.delete_event(token, refresh_token, calendar_id, events[1].id)
   end
 
 


### PR DESCRIPTION
- added `info` methods on `event` object to produce a hash rendered as json by microservice
- added hash responses for create `calendar` and `event` methods
- added test for list of `events`
